### PR TITLE
Backend feat fix serializer

### DIFF
--- a/backend/itm_backend/itm_backend/settings.py
+++ b/backend/itm_backend/itm_backend/settings.py
@@ -151,7 +151,7 @@ DJOSER = {
         'user_create': 'users.serializers.CustomUserCreateSerializer',
         'user': 'users.serializers.CustomUserSerializer',
         'current_user': 'users.serializers.CustomUserSerializer',
-        'set_password': 'djoser.serializers.SetPasswordSerializer',
+        # 'set_password': 'djoser.serializers.SetPasswordSerializer',
     },
     'PERMISSIONS': {
         'user': ['rest_framework.permissions.IsAuthenticated'],

--- a/backend/itm_backend/users/serializers.py
+++ b/backend/itm_backend/users/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from .models import TimeTable
+from django.contrib.auth.hashers import make_password
 
 
 User = get_user_model()
@@ -25,7 +26,14 @@ class CustomUserCreateSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = User
-        fields = ['email', 'password', 'first_name', 'last_name',]
+        fields = ['email', 'password', 'first_name', 'last_name']
+
+    def create(self, validated_data):
+        """
+        Хэшируем пароль перед сохранением в базу данных.
+        """
+        validated_data['password'] = make_password(validated_data['password'])
+        return super().create(validated_data)
 
 
 class CustomUserSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
# Кратко

Изменён Сериализатор приложения users и настройки Djoser в settings.py

# Развёрнуто

1. Изменён сериализатор:
   - CustomUserCreateSerializer: Добавлено хэширование пароля.

2. Обновлены настройки djoser в settings.py:
     - 'set_password': 'djoser.serializers.SetPasswordSerializer', - закомментирован, без него всё работает.

3. Протестировал создание пользователя через API:
   - Используйте метод POST и URL http://127.0.0.1:8000/auth/users/ в Postman.
   - В теле запроса укажите данные нового пользователя в формате JSON, например:
     ```
     {
       "email": "user@example.com",
       "password": "securepassword",
       "first_name": "John",
       "last_name": "Doe"
     }
     ```
   - Отправьте запрос, проверьте ответ от сервера и то, что ожидаемый объект создался и пароль захэширован.
  
  4. Проверьте создание токена через API:
     - Используйте метод POST и URL http://127.0.0.1:8000/auth/jwt/create/ в Postman.
   - В теле запроса укажите данные нового пользователя в формате JSON, например:
     ```
     {
       "email": "user@example.com",
       "password": "securepassword"
     }
     ```
        - Отправьте запрос, проверьте ответ от сервера на наличие рабочих токенов.