### PR TITLE
fix: api url in .env

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,2 +1,5 @@
-VITE_API_ENDPOINT='http://localhost:8000/api/v1'
+# Deprecated file, we use .env instead
+# because vite.config.ts uses __API_ENDPOINT__: JSON.stringify(process.env.API_ENDPOINT)
+
+# VITE_API_ENDPOINT='http://localhost:8000/api/v1'
 # CLIENT_PORT=8000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+API_ENDPOINT=http://localhost:8000/api/v1

--- a/frontend/src/services/api/apiRequest.ts
+++ b/frontend/src/services/api/apiRequest.ts
@@ -7,7 +7,8 @@ import axios, {
 
 // Custom axios instance
 const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_ENDPOINT,
+  // baseURL: import.meta.env.VITE_API_ENDPOINT,
+  baseURL: __API_ENDPOINT__, // <-- while building it takes url from the .env file, it is configured in Vite.config.ts
   withCredentials: true,
 });
 


### PR DESCRIPTION
API url переехал в файл .env
Из него при сборке проекта в продакшен (npm run build) Vite подтягивает переменную API_ENDPOINT

В этом ПР есть файл .env.example

Если локально тестим Api, тогда
- скопировать там же .env.example
- переименовать в .env