### PR TITLE
feat: sent timezone to backend at first login

### DIFF
--- a/frontend/src/components/UI/timezone-input-template/InputTimezoneSelect.tsx
+++ b/frontend/src/components/UI/timezone-input-template/InputTimezoneSelect.tsx
@@ -7,6 +7,8 @@ import {
 import Select, { SingleValue, ActionMeta } from 'react-select';
 import styles from './InputTimezoneSelect.module.scss';
 import './SelectTzComponent.scss'; // <-- Управление стилями компонента Select, модульно пока не получилось (https://react-select.com/styles#inner-components)
+import { useDispatch } from 'src/services/hooks';
+import { authThunks } from 'src/services/slices/authSlice';
 
 type InputTimezonePropsType = {
   name: string;
@@ -18,6 +20,8 @@ type InputTimezonePropsType = {
 export const InputTimezoneSelect: React.FC<InputTimezonePropsType> = (
   props,
 ) => {
+  const dispatch = useDispatch();
+
   const labelStyle = 'altName';
   const timezones = {
     ...allTimezones,
@@ -37,8 +41,10 @@ export const InputTimezoneSelect: React.FC<InputTimezonePropsType> = (
   React.useEffect(() => {
     if (props.lastTzChoice) {
       setTz(props.lastTzChoice);
+    } else {
+      dispatch(authThunks.patchMe({ timezone: tz }));
     }
-  }, [props.lastTzChoice]);
+  }, [props.lastTzChoice, tz]);
 
   const handleSelection = (
     choice: SingleValue<ITimezoneOption>,


### PR DESCRIPTION
При первом входе, с бека приходит user с timezone: null
В компоненте InputTimezoneSelect в useEffect, добавил отправку на бек timezone, если её не существует.

Скриншоты:
1. Redux Actions при первом входе
![image](https://github.com/international-team-management/team-platform/assets/55017954/d337057b-8ddc-45da-afa5-fc5aa4784381)

2. Данные пользователя
![image](https://github.com/international-team-management/team-platform/assets/55017954/cc00bcb4-55e6-4c94-a8da-9fae8567178a)

3. После отправки на бек timezone
![image](https://github.com/international-team-management/team-platform/assets/55017954/a725f769-a893-440f-b421-aa460891d6d8)

