### PR TITLE
added project example

### DIFF
--- a/backend/itm_backend/api/services.py
+++ b/backend/itm_backend/api/services.py
@@ -2,7 +2,9 @@ import datetime
 
 from django.db.models import F
 
-from .serializers import ValidationError
+from .serializers import Project, Task, ValidationError
+
+PROJECT_EXAMPLE_NAME = "Пример проекта"
 
 
 def get_members_num_per_interval(user, project):
@@ -57,3 +59,45 @@ def get_members_num_per_interval(user, project):
                     members_counter += 1
         result.append({interval: members_counter})
     return result
+
+
+def add_project_example(user):
+    """
+    Создает пример проекта c заданиями при создании нового пользователя.
+    """
+
+    tasks_names = [
+        "Поиск инвесторов на 'Форум Развития 2023'",
+        "Создание новой таблицы лидеров по велогонке на стадионе во Франции",
+        "Заново произвести замер всех изменений за сутки в краторе вулкана на острове Ява",
+        "Создание новой таблицы лидеров по велогонке на стадионе во Франции",
+        "Заново произвести замер всех изменений за сутки в краторе вулкана на острове Ява",
+        "Поиск инвесторов на 'Форум Развития 2023'",
+        "Заново произвести замер всех изменений за сутки в краторе вулкана на острове Ява",
+    ]
+    tasks_deadlines = [30, 7, 10, 7, 10, 30, 10]
+    tasks_statuses = ["backlog", "backlog", "backlog", "todo", "in_progress", "in_review", "done"]
+    tasks_priorities = ["average", "minimum", "maximum", "minimum", "maximum", "average", "maximum"]
+
+    project = Project.objects.create(
+        name=PROJECT_EXAMPLE_NAME,
+        description="Пример проекта",
+        owner=user,
+        deadline=datetime.date.today() + datetime.timedelta(days=365),
+        priority="minimum",
+    )
+
+    tasks = []
+    for name, deadline, status, priority in zip(tasks_names, tasks_deadlines, tasks_statuses, tasks_priorities):
+        task = Task(
+            creator=user,
+            task_project=project,
+            name=name,
+            description=name,
+            deadline=datetime.date.today() + datetime.timedelta(days=deadline),
+            status=status,
+            priority=priority,
+        )
+        tasks.append(task)
+    Task.objects.bulk_create(tasks)
+    return project

--- a/backend/itm_backend/api/views.py
+++ b/backend/itm_backend/api/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from projects.models import Project, Task
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -13,6 +13,7 @@ from .serializers import (
     TaskPostSerializer,
     TeamSerializer,
 )
+from .services import PROJECT_EXAMPLE_NAME, add_project_example
 
 
 class ProjectViewSet(viewsets.ModelViewSet):
@@ -35,6 +36,13 @@ class ProjectViewSet(viewsets.ModelViewSet):
         project = get_object_or_404(Project, pk=pk)
         serializer = TeamSerializer(project, context={"request": request})
         return Response(serializer.data)
+
+    @action(detail=False, methods=["get"], permission_classes=[IsAuthenticated])
+    def project_example(self, request):
+        project = Project.objects.filter(owner=request.user, name=PROJECT_EXAMPLE_NAME).first()
+        if not project:
+            project = add_project_example(request.user)
+        return redirect("project-detail", pk=project.id)
 
 
 class TaskViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Добавил получение примера проекта на эндпоинт /api/v1/projects/project_example (get запрос). При запросе проверяется, есть ли у пользователя проект с именем "Пример проекта". Если есть, то происходит редирект на него. Если проекта нет, то он создается и тоже редирект. Насчет редиректа не знаю как лучше будет, пока реализовал в таком виде.
Может быть по этой ручке лучше будет просто отдавать id нужного проекта, а фронты сами редирект сделают как им нужно?
UPD: ну и может быть не через get, а через post запрос лучше делать? Код от этого не меняется никак, но может правильнее делать post, т.к. этим запросом может создаваться новый объект