### PR TITLE
Backend - urls users/me/ fix

### DIFF
--- a/backend/itm_backend/itm_backend/urls.py
+++ b/backend/itm_backend/itm_backend/urls.py
@@ -12,7 +12,7 @@ router.register("users", UserViewSet)
 urlpatterns = [
     path("api/v1/", include("api.urls")),
     path("admin/", admin.site.urls),
-    path("api/v1/auth/users/me", UserMeView.as_view()),
+    path("api/v1/auth/users/me/", UserMeView.as_view()),
     path("api/v1/auth/", include(router.urls)),
     path("api/v1/auth/", include("djoser.urls.jwt")),
 ]


### PR DESCRIPTION
Из-за отсутствия / в конце строчки api/v1/auth/users/me:
`    path("api/v1/auth/users/me/", UserMeView.as_view()),`
Не работал frontend (нельзя было войти в профиль).
Исправил.