### PR TITLE
Fixed mistakes from flake8 in pre-commit

### DIFF
--- a/backend/itm_backend/api/serializers.py
+++ b/backend/itm_backend/api/serializers.py
@@ -1,13 +1,15 @@
 import base64
 
-from api.services import add_project_example, get_members_num_per_interval
-from api.validators import validate_first_last_names, validate_offset, validate_password
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
 from django.core.files.base import ContentFile
-from projects.models import Project, Task, TaskUser
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
+
+from api.services import add_project_example, get_members_num_per_interval
+from api.validators import (validate_first_last_names, validate_offset,
+                            validate_password)
+from projects.models import Project, Task, TaskUser
 from users.models import TimeZone
 
 User = get_user_model()

--- a/backend/itm_backend/api/serializers.py
+++ b/backend/itm_backend/api/serializers.py
@@ -1,17 +1,14 @@
 import base64
 
+from api.services import add_project_example, get_members_num_per_interval
+from api.validators import validate_first_last_names, validate_offset, validate_password
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
 from django.core.files.base import ContentFile
+from projects.models import Project, Task, TaskUser
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-
-from projects.models import Project, Task, TaskUser
 from users.models import TimeZone
-
-from .services import add_project_example, get_members_num_per_interval
-from .validators import (validate_first_last_names, validate_offset,
-                         validate_password)
 
 User = get_user_model()
 
@@ -257,8 +254,7 @@ class ProjectPostSerializer(serializers.ModelSerializer):
         for task in validated_data["tasks"]:
             if task.task_project.id != instance.id:
                 raise ValidationError(
-                    f"Задача '{task}' с id = {task.id} принадлежит другому "
-                    f"проекту и не может быть добавлена."
+                    f"Задача '{task}' с id = {task.id} принадлежит другому " f"проекту и не может быть добавлена."
                 )
         return super().update(instance, validated_data)
 

--- a/backend/itm_backend/api/urls.py
+++ b/backend/itm_backend/api/urls.py
@@ -1,11 +1,9 @@
-from api.views import ProjectViewSet, TaskViewSet
 from django.urls import include, path
-from drf_spectacular.views import (
-    SpectacularAPIView,
-    SpectacularRedocView,
-    SpectacularSwaggerView,
-)
+from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
+                                   SpectacularSwaggerView)
 from rest_framework.routers import SimpleRouter
+
+from api.views import ProjectViewSet, TaskViewSet
 
 router = SimpleRouter()
 router.register("projects", ProjectViewSet)

--- a/backend/itm_backend/api/urls.py
+++ b/backend/itm_backend/api/urls.py
@@ -1,3 +1,4 @@
+from api.views import ProjectViewSet, TaskViewSet
 from django.urls import include, path
 from drf_spectacular.views import (
     SpectacularAPIView,
@@ -6,11 +7,9 @@ from drf_spectacular.views import (
 )
 from rest_framework.routers import SimpleRouter
 
-from .views import ProjectViewSet, TaskViewSet
-
 router = SimpleRouter()
 router.register("projects", ProjectViewSet)
-router.register(r"projects/(?P<projects_id>\d+)/tasks", TaskViewSet)
+router.register(r"projects/(?P<projects_id>\d+)/tasks", TaskViewSet, basename="tasks")
 
 urlpatterns = [
     path("schema/", SpectacularAPIView.as_view(), name="schema"),

--- a/backend/itm_backend/api/views.py
+++ b/backend/itm_backend/api/views.py
@@ -111,7 +111,7 @@ class TaskViewSet(viewsets.ModelViewSet):
     queryset = Task.objects.all()
 
     def get_queryset(self):
-        task_project_id = self.kwargs["projects_id"]
+        task_project_id = self.kwargs.get("projects_id")
         queryset = Task.objects.filter(task_project=task_project_id)
         return queryset
 

--- a/backend/itm_backend/api/views.py
+++ b/backend/itm_backend/api/views.py
@@ -1,31 +1,21 @@
-from api.permissions import IsOwnerOrReadOnly, IsParticipantOrReadOnly
-from api.serializers import (
-    CustomUserCreateSerializer,
-    CustomUserSerializer,
-    ProjectGetSerializer,
-    ProjectPostSerializer,
-    SetPasswordSerializer,
-    TaskGetSerializer,
-    TaskPostSerializer,
-    TeamSerializer,
-)
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
-from projects.models import Project, Task
 from rest_framework import mixins, status, views, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import SAFE_METHODS, AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
-from .decorators import (
-    project_view_set_schema,
-    project_view_team_schema,
-    task_view_set_schema,
-    user_me_view_patch_schema,
-    user_me_view_request_schema,
-    user_view_set_schema,
-)
+from api.permissions import IsOwnerOrReadOnly, IsParticipantOrReadOnly
+from api.serializers import (CustomUserCreateSerializer, CustomUserSerializer,
+                             ProjectGetSerializer, ProjectPostSerializer,
+                             SetPasswordSerializer, TaskGetSerializer,
+                             TaskPostSerializer, TeamSerializer)
+from projects.models import Project, Task
+
+from .decorators import (project_view_set_schema, project_view_team_schema,
+                         task_view_set_schema, user_me_view_patch_schema,
+                         user_me_view_request_schema, user_view_set_schema)
 
 User = get_user_model()
 

--- a/backend/itm_backend/api/views.py
+++ b/backend/itm_backend/api/views.py
@@ -108,7 +108,6 @@ class ProjectViewSet(viewsets.ModelViewSet):
 @task_view_set_schema
 class TaskViewSet(viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, IsParticipantOrReadOnly)
-    queryset = Task.objects.all()
 
     def get_queryset(self):
         task_project_id = self.kwargs.get("projects_id")

--- a/backend/itm_backend/api/views.py
+++ b/backend/itm_backend/api/views.py
@@ -1,23 +1,31 @@
+from api.permissions import IsOwnerOrReadOnly, IsParticipantOrReadOnly
+from api.serializers import (
+    CustomUserCreateSerializer,
+    CustomUserSerializer,
+    ProjectGetSerializer,
+    ProjectPostSerializer,
+    SetPasswordSerializer,
+    TaskGetSerializer,
+    TaskPostSerializer,
+    TeamSerializer,
+)
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
+from projects.models import Project, Task
 from rest_framework import mixins, status, views, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import SAFE_METHODS, AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
-from projects.models import Project, Task
-
-from .decorators import (project_view_project_example, project_view_set_schema,
-                         project_view_team_schema, task_view_set_schema,
-                         user_me_view_patch_schema,
-                         user_me_view_request_schema, user_view_set_schema)
-from .permissions import IsOwnerOrReadOnly, IsParticipantOrReadOnly
-from .serializers import (CustomUserCreateSerializer, CustomUserSerializer,
-                          ProjectGetSerializer, ProjectPostSerializer,
-                          SetPasswordSerializer, TaskGetSerializer,
-                          TaskPostSerializer, TeamSerializer)
-from .services import PROJECT_EXAMPLE_NAME, add_project_example
+from .decorators import (
+    project_view_set_schema,
+    project_view_team_schema,
+    task_view_set_schema,
+    user_me_view_patch_schema,
+    user_me_view_request_schema,
+    user_view_set_schema,
+)
 
 User = get_user_model()
 
@@ -102,11 +110,16 @@ class TaskViewSet(viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated, IsParticipantOrReadOnly)
     queryset = Task.objects.all()
 
+    def get_queryset(self):
+        task_project_id = self.kwargs["projects_id"]
+        queryset = Task.objects.filter(task_project=task_project_id)
+        return queryset
+
     def get_serializer_class(self):
         if self.request.method in SAFE_METHODS:
             return TaskGetSerializer
         return TaskPostSerializer
 
     def perform_create(self, serializer):
-        project = get_object_or_404(Project, pk=self.kwargs.get("task_project_id"))
-        serializer.save(creator=self.request.user, project=project)
+        project = get_object_or_404(Project, pk=self.kwargs.get("projects_id"))
+        serializer.save(creator=self.request.user, task_project=project)

--- a/backend/itm_backend/projects/admin.py
+++ b/backend/itm_backend/projects/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from projects.models import Project, ProjectUser, Task, TaskUser
 
 

--- a/backend/itm_backend/projects/admin.py
+++ b/backend/itm_backend/projects/admin.py
@@ -1,6 +1,5 @@
 from django.contrib import admin
-
-from .models import Project, ProjectUser, Task, TaskUser
+from projects.models import Project, ProjectUser, Task, TaskUser
 
 
 class ProjectUserInline(admin.TabularInline):


### PR DESCRIPTION
Исправил. Добавил def get_queryset(self): во вьюху для Тасков.
Также удалил несолько неиспользуемых переменных, на которые ругался flake8 во время пре-коммита:
На всякий случай их обозначу:
backend/itm_backend/api/views.py:12:1: F401 'api.services.PROJECT_EXAMPLE_NAME' imported but unused
backend/itm_backend/api/views.py:12:1: F401 'api.services.add_project_example' imported but unused
backend/itm_backend/api/views.py:22:1: F401 '.decorators.project_view_project_example' imported but unused
Я их потер!