### PR TITLE
Add project member via email

### DIFF
--- a/backend/itm_backend/api/permissions.py
+++ b/backend/itm_backend/api/permissions.py
@@ -30,3 +30,14 @@ class IsParticipantOrReadOnly(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
         return request.user in obj.task_project.participants.all()
+
+
+class IsProjectParticipant(permissions.BasePermission):
+    """
+    Разрешает только участникам проекта добавлять пользователей в команду проекта.
+    """
+
+    def has_permission(self, request, view):
+        project_id = view.kwargs.get("pk")
+        project = get_object_or_404(Project, pk=project_id)
+        return request.user in project.participants.all()

--- a/backend/itm_backend/api/serializers.py
+++ b/backend/itm_backend/api/serializers.py
@@ -301,6 +301,11 @@ class TeamSerializer(serializers.ModelSerializer):
     def validate(self, data):
         """Валидация добавления участника проекта."""
         if self.context["request"].method == "POST":
+            adding_user = self.context["request"].user  # пользователь добавляющий участника
+            if not adding_user.timezone:
+                raise ValidationError(
+                    "Вы пока не можете добавить участника в команду. Пожалуйста, установите таймзону в своем профиле."
+                )
             user = self.context["user"]
             project = self.context["project"]
             if ProjectUser.objects.filter(user_id=user, project_id=project).exists():


### PR DESCRIPTION
Сделал добавление пользователя в проект через ручку `/api/v1/projects/id/add_member/` по его email.
В теле post запроса необходимо передавать email в виде:
```
{
    "email": "example@example.ru"
}
```
Мы не обсуждали, кто может добавлять пользователей в проект. Сделал, что добавлять могут участники проекта.
Также добавил валидацию на то, чтобы нельзя было добавить пользователя, который уже в проекте и неактивного пользователя.